### PR TITLE
起動時に以前のディレクトリの画像を表示する 

### DIFF
--- a/ImageViewer/Form1.Designer.cs
+++ b/ImageViewer/Form1.Designer.cs
@@ -86,7 +86,6 @@
             // 
             // pictureBox1
             // 
-            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
             this.pictureBox1.Location = new System.Drawing.Point(0, 0);
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.Size = new System.Drawing.Size(1920, 1080);

--- a/ImageViewer/Form1.Designer.cs
+++ b/ImageViewer/Form1.Designer.cs
@@ -86,6 +86,7 @@
             // 
             // pictureBox1
             // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
             this.pictureBox1.Location = new System.Drawing.Point(0, 0);
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.Size = new System.Drawing.Size(1920, 1080);

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -29,6 +29,9 @@ namespace ImageViewer
                 {
                     Console.WriteLine(elem);
                 }
+                pictureBox1.Image = new Bitmap(files[0]);
+                trackBar.Minimum = 1;
+                trackBar.Maximum = files.Length;
             }
             Console.WriteLine(trackBar.TickStyle);
         }
@@ -51,7 +54,7 @@ namespace ImageViewer
         private void trackBar1_Scroll_1(object sender, EventArgs e)
         {
             Console.WriteLine("Current Position: " + trackBar.Value);
-
+            Console.WriteLine(files[trackBar.Value - 1]);
             pictureBox1.Image = new Bitmap(files[trackBar.Value - 1]);
         }
 

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -53,8 +53,6 @@ namespace ImageViewer
 
         private void trackBar1_Scroll_1(object sender, EventArgs e)
         {
-            Console.WriteLine("Current Position: " + trackBar.Value);
-            Console.WriteLine(files[trackBar.Value - 1]);
             pictureBox1.Image = new Bitmap(files[trackBar.Value - 1]);
         }
 


### PR DESCRIPTION
Resolve #2 
# 概要
以前は、起動時のPictureBoxに適当なダミー画像を表示していた。
この挙動を変更し、前回設定したディレクトリの画像を表示するように変更を行った。

# 変更内容
今までは, FungusZoomの画像をデフォルトとして出していた。
![fungus](https://user-images.githubusercontent.com/4714658/49069672-30453880-f26d-11e8-8756-87231e965bdb.png)
表示したいディレクトリを選択し、一度アプリケーションを終了する。
![path](https://user-images.githubusercontent.com/4714658/49069736-5ec31380-f26d-11e8-8277-d3a3ad1fb0bd.PNG)
次に起動すると、前回のパスが保存されている。
![app2](https://user-images.githubusercontent.com/4714658/49069771-726e7a00-f26d-11e8-8d49-26d0dd7456ef.PNG)

# 影響範囲
特になし

# 動作要件
特になし

# 補足
特になし
