### PR TITLE
拡大/縮小の実装 #1

### DIFF
--- a/ImageViewer/Form1.Designer.cs
+++ b/ImageViewer/Form1.Designer.cs
@@ -127,9 +127,6 @@
             this.toolStrip1.PerformLayout();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
-            this.SetStyle(System.Windows.Forms.ControlStyles.DoubleBuffer, true);
-            this.SetStyle(System.Windows.Forms.ControlStyles.UserPaint, true);
-            this.SetStyle(System.Windows.Forms.ControlStyles.AllPaintingInWmPaint, true);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/ImageViewer/Form1.Designer.cs
+++ b/ImageViewer/Form1.Designer.cs
@@ -103,7 +103,7 @@
             this.comboBox1.Size = new System.Drawing.Size(58, 20);
             this.comboBox1.TabIndex = 7;
             this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
-            string[] s = {"100", "200", "400", "800", "1600" };
+            string[] s = {"100%", "200%", "400%", "800%", "1600%" };
             this.comboBox1.Items.AddRange(s);
             // 
             // Form1
@@ -127,6 +127,9 @@
             this.toolStrip1.PerformLayout();
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
+            this.SetStyle(System.Windows.Forms.ControlStyles.DoubleBuffer, true);
+            this.SetStyle(System.Windows.Forms.ControlStyles.UserPaint, true);
+            this.SetStyle(System.Windows.Forms.ControlStyles.AllPaintingInWmPaint, true);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/ImageViewer/Form1.Designer.cs
+++ b/ImageViewer/Form1.Designer.cs
@@ -34,6 +34,7 @@
             this.preferenceButton = new System.Windows.Forms.ToolStripButton();
             this.panel1 = new System.Windows.Forms.Panel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar)).BeginInit();
             this.toolStrip1.SuspendLayout();
             this.panel1.SuspendLayout();
@@ -94,11 +95,23 @@
             this.pictureBox1.TabIndex = 0;
             this.pictureBox1.TabStop = false;
             // 
+            // comboBox1
+            // 
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Location = new System.Drawing.Point(55, 2);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(58, 20);
+            this.comboBox1.TabIndex = 7;
+            this.comboBox1.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);
+            string[] s = {"100", "200", "400", "800", "1600" };
+            this.comboBox1.Items.AddRange(s);
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1109, 677);
+            this.Controls.Add(this.comboBox1);
             this.Controls.Add(this.toolStrip1);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.trackBar);
@@ -126,6 +139,7 @@
         private System.Windows.Forms.ToolStripButton preferenceButton;
         private System.Windows.Forms.Panel panel1;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.ComboBox comboBox1;
     }
 }
 

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -66,7 +66,7 @@ namespace ImageViewer
             pictureBox1.Hide();
             pictureBox1.Image = new Bitmap(files[trackBar.Value - 1]);
             pictureBox1.Show();
-            imageZoom(zoomRatio);
+            imageZoom();
             panel1.AutoScrollPosition = new Point(-coordinateX, -coordinateY);
         }
 
@@ -111,10 +111,10 @@ namespace ImageViewer
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
             zoomRatio = int.Parse((comboBox1.Text).Replace("%", ""))/100;
-            imageZoom(zoomRatio);
+            imageZoom();
         }
 
-        private void imageZoom(int zoomRatio)
+        private void imageZoom()
         {
             if (prevRatio < zoomRatio)
             {

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -16,6 +16,7 @@ namespace ImageViewer
     {
         private string[] files;
         private string prevPath;
+        int prevRatio = 1;
 
         public Form1()
         {
@@ -31,6 +32,7 @@ namespace ImageViewer
                 }
             }
             Console.WriteLine(trackBar.TickStyle);
+            comboBox1.SelectedIndex = 0;
         }
 
         private void trackBar1_Scroll(object sender, EventArgs e)
@@ -91,6 +93,36 @@ namespace ImageViewer
         private string[] getImagesPath()
         {
             return Directory.GetFiles(Properties.Settings.Default.imagePath).Where(elem => Regex.IsMatch(elem, "(.jpg|.png|.bmp)$")).ToArray();
+        }
+
+        private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            
+            int zoomRatio = int.Parse(comboBox1.Text)/100;
+
+            if(prevRatio < zoomRatio)
+            {
+                pictureBox1.Refresh();
+                Bitmap bmp = new Bitmap(
+                pictureBox1.Image,
+                pictureBox1.Image.Width * zoomRatio,
+                pictureBox1.Image.Height * zoomRatio);
+                pictureBox1.Image = bmp;
+                prevRatio = zoomRatio;
+            }
+            else
+            {
+                pictureBox1.Refresh();
+                double zp = (double)zoomRatio / (double)prevRatio;
+                Bitmap bmp = new Bitmap(
+                pictureBox1.Image,
+                (int)(pictureBox1.Image.Width * (zp)),
+                (int)(pictureBox1.Image.Height * (zp)));
+                pictureBox1.Image = bmp;
+                prevRatio = zoomRatio;
+               
+            }
+            
         }
     }
 }

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -16,7 +16,10 @@ namespace ImageViewer
     {
         private string[] files;
         private string prevPath;
-        int prevRatio = 1;
+        private int prevRatio = 1;
+        private int zoomRatio = 1;
+        private int coordinateX = 0;
+        private int coordinateY = 0;
 
         public Form1()
         {
@@ -36,6 +39,9 @@ namespace ImageViewer
             }
             Console.WriteLine(trackBar.TickStyle);
             comboBox1.SelectedIndex = 0;
+            this.SetStyle(ControlStyles.DoubleBuffer, true);
+            this.SetStyle(ControlStyles.UserPaint, true);
+            this.SetStyle(ControlStyles.AllPaintingInWmPaint, true);
         }
 
         private void trackBar1_Scroll(object sender, EventArgs e)
@@ -55,7 +61,13 @@ namespace ImageViewer
 
         private void trackBar1_Scroll_1(object sender, EventArgs e)
         {
+            coordinateX = pictureBox1.Location.X;
+            coordinateY = pictureBox1.Location.Y;
+            pictureBox1.Hide();
             pictureBox1.Image = new Bitmap(files[trackBar.Value - 1]);
+            pictureBox1.Show();
+            imageZoom(zoomRatio);
+            panel1.AutoScrollPosition = new Point(-coordinateX, -coordinateY);
         }
 
         private void textBox1_TextChanged(object sender, EventArgs e)
@@ -98,22 +110,32 @@ namespace ImageViewer
 
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            
-            int zoomRatio = int.Parse(comboBox1.Text)/100;
+            zoomRatio = int.Parse((comboBox1.Text).Replace("%", ""))/100;
+            imageZoom(zoomRatio);
+        }
 
-            if(prevRatio < zoomRatio)
+        private void imageZoom(int zoomRatio)
+        {
+            if (prevRatio < zoomRatio)
             {
-                pictureBox1.Refresh();
+                double zp = (double)zoomRatio / (double)prevRatio;
                 Bitmap bmp = new Bitmap(
                 pictureBox1.Image,
-                pictureBox1.Image.Width * zoomRatio,
-                pictureBox1.Image.Height * zoomRatio);
+                (int)(pictureBox1.Image.Width * zp),
+                (int)(pictureBox1.Image.Height * zp));
+                pictureBox1.Image = bmp;
+                prevRatio = zoomRatio;
+            }else if (prevRatio == zoomRatio)
+            {
+                Bitmap bmp = new Bitmap(
+                pictureBox1.Image,
+                (int)(pictureBox1.Image.Width * zoomRatio),
+                (int)(pictureBox1.Image.Height * zoomRatio));
                 pictureBox1.Image = bmp;
                 prevRatio = zoomRatio;
             }
             else
             {
-                pictureBox1.Refresh();
                 double zp = (double)zoomRatio / (double)prevRatio;
                 Bitmap bmp = new Bitmap(
                 pictureBox1.Image,
@@ -121,9 +143,7 @@ namespace ImageViewer
                 (int)(pictureBox1.Image.Height * (zp)));
                 pictureBox1.Image = bmp;
                 prevRatio = zoomRatio;
-               
             }
-            
         }
     }
 }

--- a/ImageViewer/Form1.cs
+++ b/ImageViewer/Form1.cs
@@ -116,16 +116,7 @@ namespace ImageViewer
 
         private void imageZoom()
         {
-            if (prevRatio < zoomRatio)
-            {
-                double zp = (double)zoomRatio / (double)prevRatio;
-                Bitmap bmp = new Bitmap(
-                pictureBox1.Image,
-                (int)(pictureBox1.Image.Width * zp),
-                (int)(pictureBox1.Image.Height * zp));
-                pictureBox1.Image = bmp;
-                prevRatio = zoomRatio;
-            }else if (prevRatio == zoomRatio)
+            if (prevRatio == zoomRatio)
             {
                 Bitmap bmp = new Bitmap(
                 pictureBox1.Image,


### PR DESCRIPTION
<!-- 必ずしも全ての項目を埋めなくてよい -->

# 概要
<!--
変更の目的，もしくは関連する Issue の番号を記述する
-->
#1 
拡大縮小をつけたい。スクロールしたり画像を変更しても拡大縮小したままにしたい。

# 変更内容
<!--
ビューの変更がある場合はスクリーンショットによる比較などがあるとわかりやすい

|変更前|変更後|
|:-:|:-:|
|変更なし|変更なし|
-->
- 拡大縮小の倍率を示すcomboBoxを設定の横に設置。100, 200, 400, 800, 1600%まで対応。
- AutoScrollPositionを使って、スクロールバーのX、Yの値を画像を変えても反映されるように。
- 拡大縮小はimageZoomというくそみたいな関数に任せた。１つ前の倍率を覚えておいて、変えた倍率と比較してpictureBoxのwidthとheightに乗算する。

# 影響範囲
<!--
この関数を変更したのでこの機能にも影響があるなど
-->

# 動作要件
<!--
動作に必要な環境変数や依存関係，データベースの更新など
-->

# 補足
<!--
レビューをする際に注意するべき点，ローカル環境で試す際の注意点など
-->
